### PR TITLE
Switch ujson to json

### DIFF
--- a/jupyterlab_iframe/extension.py
+++ b/jupyterlab_iframe/extension.py
@@ -1,4 +1,4 @@
-import ujson
+import json
 from notebook.base.handlers import IPythonHandler
 from notebook.utils import url_path_join
 
@@ -9,7 +9,7 @@ class IFrameHandler(IPythonHandler):
         self.welcome = welcome
 
     def get(self):
-        self.finish(ujson.dumps({'welcome': self.welcome or '', 'sites': self.sites}))
+        self.finish(json.dumps({'welcome': self.welcome or '', 'sites': self.sites}))
 
 
 def load_jupyter_server_extension(nb_server_app):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 jupyterlab
-ujson


### PR DESCRIPTION
`ujson` is overkill for the use case here. It adds an unnecessary dependency and complicated the install.

Closes #21 and makes #17 unnecessary