### PR TITLE
Support JupyterLab 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "jest": "^24.1.0",
     "jest-transform-css": "^2.0.0",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.6.1",
+    "rimraf": "^3.0.0",
     "ts-jest": "^23.10.4",
     "tslint": "^5.14.0",
-    "typescript": "^3.1.6"
+    "typescript": "~3.7.0"
   }
 }


### PR DESCRIPTION
Fixes #53. I did not make both JupyterLab 1.0.0 and JupyterLab 2.0.0 valid at the same time, which makes anyone attempting to install this extensions latest release will not get the absolute latest with JupyterLab ^1.0.0.

I also have not tested this yet, I'm acting botlike currently running around to various projects making these PRs to support JupyterLab 2.0.0 ;)